### PR TITLE
build: use relative paths to tfhe-rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-TFHE_RS_FOLDER=${ROOT_DIR}/tfhe-rs/
-CGO_CFLAGS="-I${TFHE_RS_FOLDER}/target/release/"
-CGO_LDFLAGS="-L${TFHE_RS_FOLDER}/target/release/"
-
 .PHONY: build
 build: build-tfhe-rs-capi
-	cd fhevm && CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} go build .
+	cd fhevm && go build .
 
 .PHONY: test
 test: build-tfhe-rs-capi
-	cd fhevm && CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} go test -v .
+	cd fhevm && go test -v .
 
 .PHONY: build-tfhe-rs-capi
 build-tfhe-rs-capi:
 	cd tfhe-rs && make build_c_api_experimental_deterministic_fft
+
+.PHONY: clean
+clean:
+	cd tfhe-rs && cargo clean

--- a/fhevm/tfhe.go
+++ b/fhevm/tfhe.go
@@ -17,8 +17,8 @@
 package fhevm
 
 /*
-#cgo CFLAGS: -O3 -I.
-#cgo LDFLAGS: -l:libtfhe.a -lm
+#cgo CFLAGS: -O3 -I../tfhe-rs/target/release
+#cgo LDFLAGS: -L../tfhe-rs/target/release -l:libtfhe.a -lm
 
 #include <tfhe.h>
 


### PR DESCRIPTION
Use relative paths to tfhe-rs instead of environment variables.