### PR TITLE
Fix static linking on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ test: build-tfhe-rs-capi
 
 .PHONY: build-tfhe-rs-capi
 build-tfhe-rs-capi:
-	cd tfhe-rs && make build_c_api_experimental_deterministic_fft
+	cd tfhe-rs && make build_c_api_experimental_deterministic_fft \
+	&& cd target/release && rm -f *.dylib *.dll *.so
 
 .PHONY: clean
 clean:

--- a/fhevm/tfhe.go
+++ b/fhevm/tfhe.go
@@ -19,8 +19,8 @@ package fhevm
 /*
 #cgo linux CFLAGS: -O3 -I../tfhe-rs/target/release
 #cgo linux LDFLAGS: -L../tfhe-rs/target/release -l:libtfhe.a -lm
-#cgo darwin CFLAGS: -O3 -I../tfhe-rs/target/release ../tfhe-rs/target/release/libtfhe.a
-#cgo darwin LDFLAGS: -framework Security -lm
+#cgo darwin CFLAGS: -O3 -I../tfhe-rs/target/release
+#cgo darwin LDFLAGS: -framework Security -L../tfhe-rs/target/release -ltfhe -lm
 
 #include <tfhe.h>
 


### PR DESCRIPTION
`-framework Security` flag was missing, when building subnet-evm this flag seems to be added automatically as build works.

We remove all dynamic library builds to make sure only static library is linked by the next build step.