### PR TITLE
feat: add ciphertext delegation for opReturn

### DIFF
--- a/fhevm/errors.go
+++ b/fhevm/errors.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 )
 
-// List of EVM execution errors needed by the fhEVM
+// List of EVM execution errors needed by the fhEVM.
+// TODO: initialize errors from erros passed by users. That would make fhevm-go errors match the EVM environment's errors.
 var (
-	ErrWriteProtection = errors.New("write protection")
+	ErrExecutionReverted = errors.New("execution reverted")
 )

--- a/fhevm/interpreter.go
+++ b/fhevm/interpreter.go
@@ -3,6 +3,7 @@ package fhevm
 import "github.com/ethereum/go-ethereum/common"
 
 type ScopeContext interface {
+	GetMemory() Memory
 	GetStack() Stack
 	GetContract() Contract
 }

--- a/fhevm/memory.go
+++ b/fhevm/memory.go
@@ -1,0 +1,34 @@
+// BSD 3-Clause Clear License
+
+// Copyright © 2023 ZAMA.
+// All rights reserved.
+
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package fhevm
+
+import "github.com/holiman/uint256"
+
+type Memory interface {
+	Set(offset, size uint64, value []byte)
+	Set32(offset uint64, val *uint256.Int)
+	Resize(size uint64)
+	GetCopy(offset, size int64) (cpy []byte)
+	GetPtr(offset, size int64) []byte
+	Len() int
+	Data() []byte
+}

--- a/fhevm/precompiles.go
+++ b/fhevm/precompiles.go
@@ -25,8 +25,6 @@ type PrecompiledContract interface {
 	Run(environment *EVMEnvironment, caller common.Address, addr common.Address, input []byte, readOnly bool) (ret []byte, err error)
 }
 
-var ErrExecutionReverted = errors.New("execution reverted")
-
 var signatureFheAdd = makeKeccakSignature("fheAdd(uint256,uint256,bytes1)")
 var signatureCast = makeKeccakSignature("cast(uint256,bytes1)")
 var signatureDecrypt = makeKeccakSignature("decrypt(uint256)")


### PR DESCRIPTION
Also, add the Memory interface that can be used to abstract away the memory interface.

Add a TODO note about errors in fhevm-go not matching errors in the EVM it is integrated to. A subsequent commit will add mapping of errors such that they match across EVM and fhevm-go.