### PR TITLE
Update gas prices based on benchmarks on hpc7a

### DIFF
--- a/fhevm/params.go
+++ b/fhevm/params.go
@@ -61,11 +61,14 @@ type GasCosts struct {
 	FheDecrypt          map[FheUintType]uint64
 	FheBitwiseOp        map[FheUintType]uint64
 	FheMul              map[FheUintType]uint64
-	FheDiv              map[FheUintType]uint64
-	FheRem              map[FheUintType]uint64
+	FheScalarMul        map[FheUintType]uint64
+	FheScalarDiv        map[FheUintType]uint64
+	FheScalarRem        map[FheUintType]uint64
 	FheShift            map[FheUintType]uint64
+	FheScalarShift      map[FheUintType]uint64
 	FheLe               map[FheUintType]uint64
 	FheMinMax           map[FheUintType]uint64
+	FheScalarMinMax     map[FheUintType]uint64
 	FheNegNot           map[FheUintType]uint64
 	FheReencrypt        map[FheUintType]uint64
 	FheTrivialEncrypt   map[FheUintType]uint64
@@ -139,9 +142,9 @@ func DefaultGasCosts() GasCosts {
 			FheUint32: 189000,
 		},
 		FheNegNot: map[FheUintType]uint64{
-			FheUint8:  83000,
-			FheUint16: 108000,
-			FheUint32: 130000,
+			FheUint8:  30000,
+			FheUint16: 31000,
+			FheUint32: 32000,
 		},
 		// TODO: Costs will depend on the complexity of doing reencryption/decryption by the oracle.
 		FheReencrypt: map[FheUintType]uint64{

--- a/fhevm/precompiles.go
+++ b/fhevm/precompiles.go
@@ -354,14 +354,15 @@ func fheMulRequiredGas(environment EVMEnvironment, input []byte) uint64 {
 			logger.Error("fheMul RequiredGas() operand type mismatch", "lhs", lhs.ciphertext.fheUintType, "rhs", rhs.ciphertext.fheUintType)
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheMul[lhs.ciphertext.fheUintType]
 	} else {
 		lhs, _, err = getScalarOperands(environment, input)
 		if err != nil {
 			logger.Error("fheMul RequiredGas() scalar inputs not verified", "err", err, "input", hex.EncodeToString(input))
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheScalarMul[lhs.ciphertext.fheUintType]
 	}
-	return environment.FhevmParams().GasCosts.FheMul[lhs.ciphertext.fheUintType]
 }
 
 func fheLeRequiredGas(environment EVMEnvironment, input []byte) uint64 {
@@ -435,14 +436,15 @@ func fheShlRequiredGas(environment EVMEnvironment, input []byte) uint64 {
 			logger.Error("fheShift RequiredGas() operand type mismatch", "lhs", lhs.ciphertext.fheUintType, "rhs", rhs.ciphertext.fheUintType)
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheShift[lhs.ciphertext.fheUintType]
 	} else {
 		lhs, _, err = getScalarOperands(environment, input)
 		if err != nil {
 			logger.Error("fheShift RequiredGas() scalar inputs not verified", "err", err, "input", hex.EncodeToString(input))
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheScalarShift[lhs.ciphertext.fheUintType]
 	}
-	return environment.FhevmParams().GasCosts.FheShift[lhs.ciphertext.fheUintType]
 }
 
 func fheShrRequiredGas(environment EVMEnvironment, input []byte) uint64 {
@@ -468,14 +470,15 @@ func fheMinRequiredGas(environment EVMEnvironment, input []byte) uint64 {
 			logger.Error("fheMin/Max RequiredGas() operand type mismatch", "lhs", lhs.ciphertext.fheUintType, "rhs", rhs.ciphertext.fheUintType)
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheMinMax[lhs.ciphertext.fheUintType]
 	} else {
 		lhs, _, err = getScalarOperands(environment, input)
 		if err != nil {
 			logger.Error("fheMin/Max RequiredGas() scalar inputs not verified", "err", err, "input", hex.EncodeToString(input))
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheScalarMinMax[lhs.ciphertext.fheUintType]
 	}
-	return environment.FhevmParams().GasCosts.FheMinMax[lhs.ciphertext.fheUintType]
 }
 
 func fheMaxRequiredGas(environment EVMEnvironment, input []byte) uint64 {
@@ -519,8 +522,8 @@ func fheDivRequiredGas(environment EVMEnvironment, input []byte) uint64 {
 			logger.Error("fheDiv RequiredGas() scalar inputs not verified", "err", err, "input", hex.EncodeToString(input))
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheScalarDiv[lhs.ciphertext.fheUintType]
 	}
-	return environment.FhevmParams().GasCosts.FheDiv[lhs.ciphertext.fheUintType]
 }
 
 func fheRemRequiredGas(environment EVMEnvironment, input []byte) uint64 {
@@ -540,8 +543,8 @@ func fheRemRequiredGas(environment EVMEnvironment, input []byte) uint64 {
 			logger.Error("fheRem RequiredGas() scalar inputs not verified", "err", err, "input", hex.EncodeToString(input))
 			return 0
 		}
+		return environment.FhevmParams().GasCosts.FheScalarRem[lhs.ciphertext.fheUintType]
 	}
-	return environment.FhevmParams().GasCosts.FheRem[lhs.ciphertext.fheUintType]
 }
 
 func fheBitAndRequiredGas(environment EVMEnvironment, input []byte) uint64 {


### PR DESCRIPTION
Here the raw benchmarks on hpc7a

```
    benchmarks_test.go:42: and8 in 21.143698ms => 30000
    benchmarks_test.go:42: and16 in 22.125934ms => 31000
    benchmarks_test.go:42: and32 in 24.170654ms => 34000
    benchmarks_test.go:42: eq8 in 36.326295ms => 51000
    benchmarks_test.go:42: eq16 in 38.692888ms => 55000
    benchmarks_test.go:42: eq32 in 58.292808ms => 83000
    benchmarks_test.go:42: ScalarEq8 in 35.21361ms => 50000
    benchmarks_test.go:42: ScalarEq16 in 37.363632ms => 53000
    benchmarks_test.go:42: ScalarEq32 in 39.800014ms => 56000
    benchmarks_test.go:42: shr8 in 152.739262ms => 218000
    benchmarks_test.go:42: shr16 in 191.582471ms => 273000
    benchmarks_test.go:42: shr32 in 234.625112ms => 335000
    benchmarks_test.go:42: ScalarShr8 in 94.572995ms => 135000
    benchmarks_test.go:42: ScalarShr16 in 112.860578ms => 161000
    benchmarks_test.go:42: ScalarShr32 in 132.264398ms => 188000
    benchmarks_test.go:42: min8 in 151.052623ms => 215000
    benchmarks_test.go:42: min16 in 190.704772ms => 272000
    benchmarks_test.go:42: min32 in 232.669845ms => 332000
    benchmarks_test.go:42: ScalarMin8 in 91.77278ms => 131000
    benchmarks_test.go:42: ScalarMin16 in 111.876571ms => 159000
    benchmarks_test.go:42: ScalarMin32 in 132.630337ms => 189000
    benchmarks_test.go:42: add8 in 76.412519ms => 109000
    benchmarks_test.go:42: add16 in 97.260445ms => 138000
    benchmarks_test.go:42: add32 in 120.681062ms => 172000
    benchmarks_test.go:42: ScalarAdd8 in 70.201021ms => 100000
    benchmarks_test.go:42: ScalarAdd16 in 95.447686ms => 136000
    benchmarks_test.go:42: ScalarAdd32 in 117.421947ms => 167000
    benchmarks_test.go:42: sub8 in 73.732867ms => 105000
    benchmarks_test.go:42: sub16 in 97.510986ms => 139000
    benchmarks_test.go:42: sub32 in 121.021967ms => 172000
    benchmarks_test.go:42: ScalarSub8 in 72.724336ms => 103000
    benchmarks_test.go:42: ScalarSub16 in 94.672753ms => 135000
    benchmarks_test.go:42: ScalarSub32 in 117.869454ms => 168000
    benchmarks_test.go:42: mul8 in 130.182512ms => 185000
    benchmarks_test.go:42: mul16 in 176.784066ms => 252000
    benchmarks_test.go:42: mul32 in 252.799735ms => 361000
    benchmarks_test.go:42: ScalarMul8 in 89.700283ms => 128000
    benchmarks_test.go:42: ScalarMul16 in 92.705605ms => 132000
    benchmarks_test.go:42: ScalarMul32 in 117.668837ms => 168000
    benchmarks_test.go:42: ScalarDiv8 in 149.751403ms => 213000
    benchmarks_test.go:42: ScalarDiv16 in 271.742097ms => 388000
    benchmarks_test.go:42: ScalarDiv32 in 237.610672ms => 339000
    benchmarks_test.go:42: IfThenElse8 in 38.806488ms => 55000
    benchmarks_test.go:42: IfThenElse16 in 42.468405ms => 60000
    benchmarks_test.go:42: IfThenElse32 in 46.059083ms => 65000
    ```