### PR TITLE
feat: Use local decrypt/reencrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the Github issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+The issue numbers will later be link-ified during the release process so you do
+not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking CLI commands and REST routes used by end-users.
+"API Breaking" for breaking exported APIs used by developers building on SDK.
+"State Machine Breaking" for any changes that result in a different AppState given same genesisState and txList.
+
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+# Changelog
+
+## Unreleased
+
+### Features
+
+- [#73](https://github.com/zama-ai/fhevm-go/pull/73): Switch to use local decrypt/reencrypt call to `tfhe-rs` instead of doing a gRPC call to a KMS. This means that the `KMS_ENDPOINT_ADDR` environment variable is now ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
 ### Features
 


### PR DESCRIPTION
Switch to use local decrypt/reencrypt call to `tfhe-rs` instead of doing a gRPC call to a KMS.

The new code is based on https://github.com/zama-ai/go-ethereum/blob/1.10.19-zama/core/vm/contracts.go