### PR TITLE
feat: array equality as a precompile

### DIFF
--- a/fhevm/fhelib.go
+++ b/fhevm/fhelib.go
@@ -209,6 +209,12 @@ var fhelibMethods = []*FheLibMethod{
 		runFunction:         fheIfThenElseRun,
 	},
 	{
+		name:                "fheArrayEq",
+		argTypes:            "(uint256[],uint256[])",
+		requiredGasFunction: fheArrayEqRequiredGas,
+		runFunction:         fheArrayEqRun,
+	},
+	{
 		name:                "fhePubKey",
 		argTypes:            "(bytes1)",
 		requiredGasFunction: fhePubKeyRequiredGas,

--- a/fhevm/params.go
+++ b/fhevm/params.go
@@ -43,6 +43,7 @@ type GasCosts struct {
 	FheShift                  map[tfhe.FheUintType]uint64
 	FheScalarShift            map[tfhe.FheUintType]uint64
 	FheEq                     map[tfhe.FheUintType]uint64
+	FheArrayEqBigArrayFactor  uint64 // TODO: either rename or come up with a better solution
 	FheLe                     map[tfhe.FheUintType]uint64
 	FheMinMax                 map[tfhe.FheUintType]uint64
 	FheScalarMinMax           map[tfhe.FheUintType]uint64
@@ -60,6 +61,8 @@ type GasCosts struct {
 
 func DefaultGasCosts() GasCosts {
 	return GasCosts{
+		FheCast:   200,
+		FhePubKey: 50,
 		FheAddSub: map[tfhe.FheUintType]uint64{
 			tfhe.FheUint4:  55000 + AdjustFHEGas,
 			tfhe.FheUint8:  84000 + AdjustFHEGas,
@@ -132,6 +135,7 @@ func DefaultGasCosts() GasCosts {
 			tfhe.FheUint64:  76000 + AdjustFHEGas,
 			tfhe.FheUint160: 80000 + AdjustFHEGas,
 		},
+		FheArrayEqBigArrayFactor: 1000,
 		FheLe: map[tfhe.FheUintType]uint64{
 			tfhe.FheUint4:  60000 + AdjustFHEGas,
 			tfhe.FheUint8:  72000 + AdjustFHEGas,

--- a/fhevm/tfhe/tfhe_test.go
+++ b/fhevm/tfhe/tfhe_test.go
@@ -1576,6 +1576,164 @@ func TfheCast(t *testing.T, fheUintTypeFrom FheUintType, fheUintTypeTo FheUintTy
 	}
 }
 
+func TfheEqArrayEqual(t *testing.T, fheUintType FheUintType) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), fheUintType))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+
+	result, err := EqArray(lhs, rhs)
+	if err != nil {
+		t.Fatalf("EqArray failed: %v", err)
+	}
+	decrypted, err := result.Decrypt()
+	if err != nil {
+		t.Fatalf("EqArray decrypt failed: %v", err)
+	}
+	if !decrypted.IsUint64() || decrypted.Uint64() != 1 {
+		t.Fatalf("EqArray expected result of 1, got: %s", decrypted.String())
+	}
+}
+
+func TfheEqArrayCompareToSelf(t *testing.T, fheUintType FheUintType) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+	rhs := lhs
+
+	result, err := EqArray(lhs, rhs)
+	if err != nil {
+		t.Fatalf("EqArray failed: %v", err)
+	}
+	decrypted, err := result.Decrypt()
+	if err != nil {
+		t.Fatalf("EqArray decrypt failed: %v", err)
+	}
+	if !decrypted.IsUint64() || decrypted.Uint64() != 1 {
+		t.Fatalf("EqArray expected result of 1, got: %s", decrypted.String())
+	}
+}
+
+func TfheEqArrayNotEqualSameLen(t *testing.T, fheUintType FheUintType) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(6), fheUintType))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+
+	result, err := EqArray(lhs, rhs)
+	if err != nil {
+		t.Fatalf("EqArray failed: %v", err)
+	}
+	decrypted, err := result.Decrypt()
+	if err != nil {
+		t.Fatalf("EqArray decrypt failed: %v", err)
+	}
+	if !decrypted.IsUint64() || decrypted.Uint64() != 0 {
+		t.Fatalf("EqArray expected result of 0, got: %s", decrypted.String())
+	}
+}
+
+func TfheEqArrayNotEqualDifferentLen(t *testing.T, fheUintType FheUintType) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), fheUintType))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), fheUintType))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), fheUintType))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(6), fheUintType))
+
+	result, err := EqArray(lhs, rhs)
+	if err != nil {
+		t.Fatalf("EqArray failed: %v", err)
+	}
+	decrypted, err := result.Decrypt()
+	if err != nil {
+		t.Fatalf("EqArray decrypt failed: %v", err)
+	}
+	if !decrypted.IsUint64() || decrypted.Uint64() != 0 {
+		t.Fatalf("EqArray expected result of 0, got: %s", decrypted.String())
+	}
+}
+
+func TestTfheEqArrayEqualBothEmpty(t *testing.T) {
+	lhs := make([]*TfheCiphertext, 0)
+	rhs := make([]*TfheCiphertext, 0)
+	result, err := EqArray(lhs, rhs)
+	if err != nil {
+		t.Fatalf("EqArray failed: %v", err)
+	}
+	decrypted, err := result.Decrypt()
+	if err != nil {
+		t.Fatalf("EqArray decrypt failed: %v", err)
+	}
+	if !decrypted.IsUint64() || decrypted.Uint64() != 1 {
+		t.Fatalf("EqArray expected result of 1, got: %s", decrypted.String())
+	}
+}
+
+func TestTfheEqArrayDifferentTypesInLhs(t *testing.T) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheUint32))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), FheUint32))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheUint64))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheUint32))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(6), FheUint32))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheUint32))
+
+	_, err := EqArray(lhs, rhs)
+	if err == nil {
+		t.Fatalf("EqArray expected error")
+	}
+}
+
+func TestTfheEqArrayDifferentTypesInRhs(t *testing.T) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheUint32))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), FheUint32))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheUint32))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheUint32))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(6), FheUint16))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheUint32))
+
+	_, err := EqArray(lhs, rhs)
+	if err == nil {
+		t.Fatalf("EqArray expected error")
+	}
+}
+
+func TestTfheEqArrayUnsupportedType(t *testing.T) {
+	lhs := make([]*TfheCiphertext, 0)
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheBool))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(7), FheBool))
+	lhs = append(lhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheBool))
+
+	rhs := make([]*TfheCiphertext, 0)
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(4), FheBool))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(6), FheBool))
+	rhs = append(rhs, new(TfheCiphertext).Encrypt(*big.NewInt(10), FheBool))
+
+	_, err := EqArray(lhs, rhs)
+	if err == nil {
+		t.Fatalf("EqArray expected error")
+	}
+}
+
 func TestTfheEncryptDecryptBool(t *testing.T) {
 	TfheEncryptDecrypt(t, FheBool)
 }
@@ -2622,4 +2780,84 @@ func TestTfhe64Cast16(t *testing.T) {
 
 func TestTfhe64Cast32(t *testing.T) {
 	TfheCast(t, FheUint64, FheUint32)
+}
+
+func TestTfheEqArrayEqual4(t *testing.T) {
+	TfheEqArrayEqual(t, FheUint4)
+}
+
+func TestTfheEqArrayEqual8(t *testing.T) {
+	TfheEqArrayEqual(t, FheUint8)
+}
+
+func TestTfheEqArrayEqual16(t *testing.T) {
+	TfheEqArrayEqual(t, FheUint16)
+}
+
+func TestTfheEqArrayEqual32(t *testing.T) {
+	TfheEqArrayEqual(t, FheUint32)
+}
+
+func TestTfheEqArrayEqual64(t *testing.T) {
+	TfheEqArrayEqual(t, FheUint64)
+}
+
+func TestTfheEqArrayCompareToSelf4(t *testing.T) {
+	TfheEqArrayCompareToSelf(t, FheUint4)
+}
+
+func TestTfheEqArrayCompareToSelf8(t *testing.T) {
+	TfheEqArrayCompareToSelf(t, FheUint8)
+}
+
+func TestTfheEqArrayCompareToSelf16(t *testing.T) {
+	TfheEqArrayCompareToSelf(t, FheUint16)
+}
+
+func TestTfheEqArrayCompareToSelf32(t *testing.T) {
+	TfheEqArrayCompareToSelf(t, FheUint32)
+}
+
+func TestTfheEqArrayCompareToSelf64(t *testing.T) {
+	TfheEqArrayCompareToSelf(t, FheUint64)
+}
+
+func TestTfheEqArrayNotEqualSameLen4(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint4)
+}
+
+func TestTfheEqArrayNotEqualSameLen8(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint8)
+}
+
+func TestTfheEqArrayNotEqualSameLen16(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint16)
+}
+
+func TestTfheEqArrayNotEqualSameLen32(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint32)
+}
+
+func TestTfheEqArrayNotEqualSameLen64(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint64)
+}
+
+func TestTfheEqArrayNotEqualDifferentLen4(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint4)
+}
+
+func TestTfheEqArrayNotEqualDifferentLen8(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint8)
+}
+
+func TestTfheEqArrayNotEqualDifferentLen16(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint16)
+}
+
+func TestTfheEqArrayNotEqualDifferentLen32(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint32)
+}
+
+func TestTfheEqArrayNotEqualDifferentLen64(t *testing.T) {
+	TfheEqArrayNotEqualSameLen(t, FheUint64)
 }

--- a/fhevm/tfhe/tfhe_wrappers.c
+++ b/fhevm/tfhe/tfhe_wrappers.c
@@ -1636,6 +1636,61 @@ void* scalar_eq_fhe_uint160(void* ct, struct U256 pt, void* sks)
 	return result;
 }
 
+void* eq_fhe_array_uint4(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks)
+{
+	FheBool* result = NULL;
+
+	checked_set_server_key(sks);
+
+	const int r = fhe_uint4_array_eq(ct1, ct1_len, ct2, ct2_len, &result);
+	if(r != 0) return NULL;
+	return result;
+}
+
+void* eq_fhe_array_uint8(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks)
+{
+	FheBool* result = NULL;
+
+	checked_set_server_key(sks);
+
+	const int r = fhe_uint8_array_eq(ct1, ct1_len, ct2, ct2_len, &result);
+	if(r != 0) return NULL;
+	return result;
+}
+
+void* eq_fhe_array_uint16(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks)
+{
+	FheBool* result = NULL;
+
+	checked_set_server_key(sks);
+
+	const int r = fhe_uint16_array_eq(ct1, ct1_len, ct2, ct2_len, &result);
+	if(r != 0) return NULL;
+	return result;
+}
+
+void* eq_fhe_array_uint32(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks)
+{
+	FheBool* result = NULL;
+
+	checked_set_server_key(sks);
+
+	const int r = fhe_uint32_array_eq(ct1, ct1_len, ct2, ct2_len, &result);
+	if(r != 0) return NULL;
+	return result;
+}
+
+void* eq_fhe_array_uint64(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks)
+{
+	FheBool* result = NULL;
+
+	checked_set_server_key(sks);
+
+	const int r = fhe_uint64_array_eq(ct1, ct1_len, ct2, ct2_len, &result);
+	if(r != 0) return NULL;
+	return result;
+}
+
 void* ne_fhe_uint4(void* ct1, void* ct2, void* sks)
 {
 	FheBool* result = NULL;

--- a/fhevm/tfhe/tfhe_wrappers.h
+++ b/fhevm/tfhe/tfhe_wrappers.h
@@ -295,6 +295,16 @@ void* scalar_eq_fhe_uint64(void* ct, uint64_t pt, void* sks);
 
 void* scalar_eq_fhe_uint160(void* ct, struct U256 pt, void* sks);
 
+void* eq_fhe_array_uint4(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
+
+void* eq_fhe_array_uint8(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
+
+void* eq_fhe_array_uint16(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
+
+void* eq_fhe_array_uint32(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
+
+void* eq_fhe_array_uint64(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
+
 void* ne_fhe_uint4(void* ct1, void* ct2, void* sks);
 
 void* ne_fhe_uint8(void* ct1, void* ct2, void* sks);


### PR DESCRIPTION
Uses geth's abi package to parse uint256[] Solidity inputs.

Add missing gas costs for FheCast and FhePubKey.