### PR TITLE
feat: size-efficient list-based ciphertext inputs

### DIFF
--- a/fhevm/evm.go
+++ b/fhevm/evm.go
@@ -60,7 +60,7 @@ func insertRandomCiphertext(environment EVMEnvironment, t tfhe.FheUintType) []by
 	ct := new(tfhe.TfheCiphertext)
 	ct.FheUintType = t
 	ct.Hash = &handle
-	insertCiphertextToMemory(environment, ct)
+	insertCiphertextToMemory(environment, handle, ct)
 	temp := nextCtHash.Clone()
 	nextCtHash.Add(temp, uint256.NewInt(1))
 	return ct.GetHash().Bytes()

--- a/fhevm/fhelib.go
+++ b/fhevm/fhelib.go
@@ -241,7 +241,7 @@ var fhelibMethods = []*FheLibMethod{
 	},
 	{
 		name:                "verifyCiphertext",
-		argTypes:            "(bytes)",
+		argTypes:            "(bytes32,address,bytes,bytes1)",
 		requiredGasFunction: verifyCiphertextRequiredGas,
 		runFunction:         verifyCiphertextRun,
 	},

--- a/fhevm/instructions.go
+++ b/fhevm/instructions.go
@@ -22,7 +22,7 @@ func OpSstore(pc *uint64, env EVMEnvironment, scope ScopeContext) ([]byte, error
 	if newValHash != oldValHash && env.IsCommitting() {
 		ct := GetCiphertextFromMemory(env, newValHash)
 		if ct != nil {
-			persistCiphertext(env, ct)
+			persistCiphertext(env, newValHash, ct)
 		}
 	}
 	// Set the SSTORE's value in the actual contract.

--- a/fhevm/interface.go
+++ b/fhevm/interface.go
@@ -47,6 +47,9 @@ type FhevmData struct {
 	// A map from a ciphertext hash to the ciphertext itself.
 	loadedCiphertexts map[common.Hash]*tfhe.TfheCiphertext
 
+	// A map from the hash of the ciphertext list to an array of expanded ciphertexts.
+	expandedInputCiphertexts map[common.Hash][]*tfhe.TfheCiphertext
+
 	nextCiphertextHashOnGasEst uint256.Int
 }
 

--- a/fhevm/operators_arithmetic.go
+++ b/fhevm/operators_arithmetic.go
@@ -42,9 +42,9 @@ func fheAddRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheAdd failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheAdd success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -66,9 +66,9 @@ func fheAddRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheAdd failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheAdd scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -108,9 +108,9 @@ func fheSubRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheSub failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheSub success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -132,9 +132,9 @@ func fheSubRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheSub failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheSub scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -174,9 +174,9 @@ func fheMulRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMul failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMul success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -198,9 +198,9 @@ func fheMulRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMul failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMul scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -239,9 +239,9 @@ func fheDivRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheDiv failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheDiv scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -280,9 +280,9 @@ func fheRemRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheRem failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheRem scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}

--- a/fhevm/operators_bit.go
+++ b/fhevm/operators_bit.go
@@ -42,9 +42,9 @@ func fheShlRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheShl failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheShl success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -66,9 +66,9 @@ func fheShlRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheShl failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheShl scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -108,9 +108,9 @@ func fheShrRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheShr failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheShr success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -132,9 +132,9 @@ func fheShrRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheShr failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheShr scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -174,9 +174,9 @@ func fheRotlRun(environment EVMEnvironment, caller common.Address, addr common.A
 			logger.Error("fheRotl failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheRotl success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -198,9 +198,9 @@ func fheRotlRun(environment EVMEnvironment, caller common.Address, addr common.A
 			logger.Error("fheRotl failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheRotl scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -240,9 +240,9 @@ func fheRotrRun(environment EVMEnvironment, caller common.Address, addr common.A
 			logger.Error("fheRotr failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheRotr success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -264,9 +264,9 @@ func fheRotrRun(environment EVMEnvironment, caller common.Address, addr common.A
 			logger.Error("fheRotr failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheRotr scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -302,9 +302,9 @@ func fheNegRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 		logger.Error("fheNeg failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheNeg success", "ct", ct.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }
@@ -339,9 +339,9 @@ func fheNotRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 		logger.Error("fheNot failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheNot success", "ct", ct.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }
@@ -386,9 +386,9 @@ func fheBitAndRun(environment EVMEnvironment, caller common.Address, addr common
 		logger.Error("fheBitAnd failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheBitAnd success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }
@@ -433,9 +433,9 @@ func fheBitOrRun(environment EVMEnvironment, caller common.Address, addr common.
 		logger.Error("fheBitOr failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheBitOr success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }
@@ -480,9 +480,9 @@ func fheBitXorRun(environment EVMEnvironment, caller common.Address, addr common
 		logger.Error("fheBitXor failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheBitXor success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }

--- a/fhevm/operators_comparison.go
+++ b/fhevm/operators_comparison.go
@@ -47,9 +47,9 @@ func fheLeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheLe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheLe success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -71,9 +71,9 @@ func fheLeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheLe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheLe scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -113,9 +113,9 @@ func fheLtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheLt failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheLt success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -137,9 +137,9 @@ func fheLtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheLt failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheLt scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -179,9 +179,9 @@ func fheEqRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheEq failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheEq success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -203,9 +203,9 @@ func fheEqRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheEq failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheEq scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -245,9 +245,9 @@ func fheGeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheGe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheGe success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -269,9 +269,9 @@ func fheGeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheGe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheGe scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -311,9 +311,9 @@ func fheGtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheGt failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheGt success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -335,9 +335,9 @@ func fheGtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheGt failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheGt scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -377,9 +377,9 @@ func fheNeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheNe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheNe success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -401,9 +401,9 @@ func fheNeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 			logger.Error("fheNe failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheNe scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -443,9 +443,9 @@ func fheMinRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMin failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMin success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -467,9 +467,9 @@ func fheMinRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMin failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMin scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -509,9 +509,9 @@ func fheMaxRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMax failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMax success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.GetHash().Hex(), "result", resultHash.Hex())
 		return resultHash[:], nil
 
@@ -533,9 +533,9 @@ func fheMaxRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 			logger.Error("fheMax failed", "err", err)
 			return nil, err
 		}
-		insertCiphertextToMemory(environment, result)
-
 		resultHash := result.GetHash()
+		insertCiphertextToMemory(environment, resultHash, result)
+
 		logger.Info("fheMax scalar success", "lhs", lhs.GetHash().Hex(), "rhs", rhs.Uint64(), "result", resultHash.Hex())
 		return resultHash[:], nil
 	}
@@ -568,9 +568,9 @@ func fheIfThenElseRun(environment EVMEnvironment, caller common.Address, addr co
 		logger.Error("fheIfThenElse failed", "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
-
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
+
 	logger.Info("fheIfThenElse success", "first", first.GetHash().Hex(), "second", second.GetHash().Hex(), "third", third.GetHash().Hex(), "result", resultHash.Hex())
 	return resultHash[:], nil
 }
@@ -676,8 +676,8 @@ func fheArrayEqRun(environment EVMEnvironment, caller common.Address, addr commo
 		logger.Error(msg, "err", err)
 		return nil, err
 	}
-	insertCiphertextToMemory(environment, result)
 	resultHash := result.GetHash()
+	insertCiphertextToMemory(environment, resultHash, result)
 	logger.Info("fheArrayEqRun success", "result", resultHash.Hex())
 	return resultHash[:], nil
 }

--- a/fhevm/operators_crypto_gas.go
+++ b/fhevm/operators_crypto_gas.go
@@ -8,14 +8,14 @@ import (
 )
 
 func verifyCiphertextRequiredGas(environment EVMEnvironment, input []byte) uint64 {
-	if len(input) <= 1 {
+	_, ct, err := parseVerifyCiphertextInput(environment, input)
+	if err != nil {
 		environment.GetLogger().Error(
-			"verifyCiphertext RequiredGas() input needs to contain a ciphertext and one byte for its type",
-			"len", len(input))
+			"verifyCiphertext RequiredGas() input parsing failed",
+			"err", err)
 		return 0
 	}
-	ctType := tfhe.FheUintType(input[len(input)-1])
-	return environment.FhevmParams().GasCosts.FheVerify[ctType]
+	return environment.FhevmParams().GasCosts.FheVerify[ct.Type()]
 }
 
 func reencryptRequiredGas(environment EVMEnvironment, input []byte) uint64 {

--- a/fhevm/operators_rand.go
+++ b/fhevm/operators_rand.go
@@ -131,12 +131,8 @@ func generateRandom(environment EVMEnvironment, caller common.Address, resultTyp
 	randBigInt := big.NewInt(0)
 	randBigInt.SetUint64(randUint)
 	randCt.TrivialEncrypt(*randBigInt, resultType)
-	insertCiphertextToMemory(environment, randCt)
-
-	if err != nil {
-		return nil, err
-	}
 	ctHash := randCt.GetHash()
+	insertCiphertextToMemory(environment, ctHash, randCt)
 	return ctHash[:], nil
 }
 

--- a/fhevm/tfhe/tfhe_key_management.go
+++ b/fhevm/tfhe/tfhe_key_management.go
@@ -24,14 +24,6 @@ func GetExpandedFheCiphertextSize(t FheUintType) (size uint, found bool) {
 	return
 }
 
-// Compact TFHE ciphertext sizes by type, in bytes.
-var compactFheCiphertextSize map[FheUintType]uint
-
-func GetCompactFheCiphertextSize(t FheUintType) (size uint, found bool) {
-	size, found = compactFheCiphertextSize[t]
-	return
-}
-
 // server key: evaluation key
 var sks unsafe.Pointer
 
@@ -64,7 +56,6 @@ func InitGlobalKeysWithNewKeys() {
 
 func initCiphertextSizes() {
 	ExpandedFheCiphertextSize = make(map[FheUintType]uint)
-	compactFheCiphertextSize = make(map[FheUintType]uint)
 
 	ExpandedFheCiphertextSize[FheBool] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheBool).Serialize()))
 	ExpandedFheCiphertextSize[FheUint4] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheUint4).Serialize()))
@@ -73,14 +64,7 @@ func initCiphertextSizes() {
 	ExpandedFheCiphertextSize[FheUint32] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheUint32).Serialize()))
 	ExpandedFheCiphertextSize[FheUint64] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheUint64).Serialize()))
 	ExpandedFheCiphertextSize[FheUint160] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheUint160).Serialize()))
-
-	compactFheCiphertextSize[FheBool] = uint(len(EncryptAndSerializeCompact(0, FheBool)))
-	compactFheCiphertextSize[FheUint4] = uint(len(EncryptAndSerializeCompact(0, FheUint4)))
-	compactFheCiphertextSize[FheUint8] = uint(len(EncryptAndSerializeCompact(0, FheUint8)))
-	compactFheCiphertextSize[FheUint16] = uint(len(EncryptAndSerializeCompact(0, FheUint16)))
-	compactFheCiphertextSize[FheUint32] = uint(len(EncryptAndSerializeCompact(0, FheUint32)))
-	compactFheCiphertextSize[FheUint64] = uint(len(EncryptAndSerializeCompact(0, FheUint64)))
-	compactFheCiphertextSize[FheUint160] = uint(len(EncryptAndSerializeCompact(0, FheUint160)))
+	ExpandedFheCiphertextSize[FheUint2048] = uint(len(new(TfheCiphertext).TrivialEncrypt(*big.NewInt(0), FheUint2048).Serialize()))
 }
 
 func InitGlobalKeysFromFiles(keysDir string) error {

--- a/fhevm/tfhe/tfhe_wrappers.go
+++ b/fhevm/tfhe/tfhe_wrappers.go
@@ -44,6 +44,8 @@ func serialize(ptr unsafe.Pointer, t FheUintType) ([]byte, error) {
 		ret = C.serialize_fhe_uint64(ptr, out)
 	case FheUint160:
 		ret = C.serialize_fhe_uint160(ptr, out)
+	case FheUint2048:
+		ret = C.serialize_fhe_uint2048(ptr, out)
 	default:
 		panic("serialize: unexpected ciphertext type")
 	}
@@ -89,14 +91,19 @@ func EncryptAndSerializeCompact(value uint64, fheUintType FheUintType) []byte {
 	case FheUint64:
 		C.public_key_encrypt_and_serialize_fhe_uint64_list(pks, C.uint64_t(value), out)
 	case FheUint160:
-		// TODO
-		// This function is used to compute ciphertext size, the given value is generally 0,
 		value_big := new(big.Int).SetUint64(value)
 		input, err := bigIntToU256(value_big)
 		if err != nil {
 			panic(err)
 		}
 		C.public_key_encrypt_and_serialize_fhe_uint160_list(pks, input, out)
+	case FheUint2048:
+		value_big := new(big.Int).SetUint64(value)
+		input, err := bigIntToU2048(value_big)
+		if err != nil {
+			panic(err)
+		}
+		C.public_key_encrypt_and_serialize_fhe_uint2048_list(pks, input, out)
 	}
 
 	ser := C.GoBytes(unsafe.Pointer(out.pointer), C.int(out.length))
@@ -104,33 +111,244 @@ func EncryptAndSerializeCompact(value uint64, fheUintType FheUintType) []byte {
 	return ser
 }
 
-// bigIntToU256 uses u256_from_big_endian_bytes to convert big.Int to U256
+// bigIntToU256 uses x to convert big.Int to U256
 func bigIntToU256(value *big.Int) (*C.U256, error) {
 	// Convert big.Int to 32-byte big-endian slice
-	bytes := value.Bytes()
-	if len(bytes) > 32 {
+	if len(value.Bytes()) > 32 {
 		return nil, fmt.Errorf("big.Int too large for U256")
 	}
-	paddedBytes := make([]byte, 32-len(bytes)) // Padding
-	paddedBytes = append(paddedBytes, bytes...)
+	bytes := make([]byte, 32)
+	value.FillBytes(bytes)
 
 	var result C.U256
-
-	_, err := C.u256_from_big_endian_bytes((*C.uint8_t)(unsafe.Pointer(&paddedBytes[0])), C.size_t(32), &result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert big.Int to U256: %v", err)
+	ret := C.u256_from_big_endian_bytes((*C.uint8_t)(unsafe.Pointer(&bytes[0])), C.size_t(32), &result)
+	if ret != 0 {
+		return nil, fmt.Errorf("failed to convert big.Int to U256: %d", ret)
 	}
+	return &result, nil
+}
 
+func bigIntToU2048(value *big.Int) (*C.U2048, error) {
+	if len(value.Bytes()) > 256 {
+		return nil, fmt.Errorf("big.Int too large for U2048")
+	}
+	bytes := make([]byte, 256)
+	value.FillBytes(bytes)
+
+	var result C.U2048
+	ret := C.U2048_from_big_endian_bytes((*C.uint8_t)(unsafe.Pointer(&bytes[0])), C.size_t(256), &result)
+	if ret != 0 {
+		return nil, fmt.Errorf("failed to convert big.Int to U2048: %d", ret)
+	}
 	return &result, nil
 }
 
 // u256ToBigInt converts a U256 to a *big.Int.
-func u256ToBigInt(u256 C.U256) *big.Int {
+func u256ToBigInt(value *C.U256) *big.Int {
 	// Allocate a byte slice with enough space (32 bytes for U256)
 	buf := make([]byte, 32)
 
 	// Call the C function to fill the buffer with the big-endian bytes of U256
-	C.u256_big_endian_bytes(u256, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+	C.u256_big_endian_bytes(*value, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
 
 	return new(big.Int).SetBytes(buf)
+}
+
+func u2048ToBigInt(value *C.U2048) *big.Int {
+	buf := make([]byte, 256)
+	C.U2048_big_endian_bytes(*value, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+	return new(big.Int).SetBytes(buf)
+}
+
+func EncryptAndSerializeCompact160List(values []big.Int) ([]byte, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact160List empty array given")
+	}
+	inputArray := make([]C.U256, len(values))
+	for i, v := range values {
+		u256, err := bigIntToU256(&v)
+		if err != nil {
+			return nil, err
+		}
+		inputArray[i] = *u256
+	}
+
+	var list *C.CompactFheUint160List
+	ret := C.compact_fhe_uint160_list_try_encrypt_with_compact_public_key_u256(&inputArray[0], (C.size_t)(len(inputArray)), (*C.CompactPublicKey)(pks), &list)
+	if ret != 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact160List failed to encrypt with %d", ret)
+	}
+	defer C.compact_fhe_uint160_list_destroy(list)
+
+	ser := C.DynamicBuffer{}
+	ret = C.compact_fhe_uint160_list_serialize(list, &ser)
+	if ret != 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact160List failed to serialize with %d", ret)
+	}
+	defer C.destroy_dynamic_buffer(&ser)
+
+	return C.GoBytes(unsafe.Pointer(ser.pointer), C.int(ser.length)), nil
+}
+
+func DeserializeAndExpandCompact160List(in []byte) ([]*TfheCiphertext, error) {
+	var list *C.CompactFheUint160List
+	ret := C.compact_fhe_uint160_list_deserialize(toDynamicBufferView(in), &list)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact160List failed to deserialize list with %d", ret)
+	}
+	defer C.compact_fhe_uint160_list_destroy(list)
+
+	var len C.size_t
+	ret = C.compact_fhe_uint160_list_len(list, &len)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact160List failed to get list length with %d", ret)
+	}
+	if len == 0 {
+		return nil, fmt.Errorf("DeserializeCompact160List length is 0")
+	}
+
+	expanded := make([]*C.FheUint160, len)
+	ret = C.compact_fhe_uint160_list_expand(list, &expanded[0], len)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact160List failed to expand list with %d", ret)
+	}
+	defer func() {
+		for _, c := range expanded {
+			C.destroy_fhe_uint160(unsafe.Pointer(c))
+		}
+	}()
+
+	cts := make([]*TfheCiphertext, 0, len)
+	for _, c := range expanded {
+		ser, err := serialize(unsafe.Pointer(c), FheUint160)
+		if err != nil {
+			return nil, err
+		}
+		ct := new(TfheCiphertext)
+		ct.Serialization = ser
+		ct.FheUintType = FheUint160
+		ct.computeHash()
+		cts = append(cts, ct)
+	}
+	return cts, nil
+}
+
+func EncryptAndSerializeCompact2048List(values []big.Int) ([]byte, error) {
+	if len(values) == 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact2048List empty array given")
+	}
+	inputArray := make([]C.U2048, len(values))
+	for i, v := range values {
+		u2048, err := bigIntToU2048(&v)
+		if err != nil {
+			return nil, err
+		}
+		inputArray[i] = *u2048
+	}
+
+	var list *C.CompactFheUint2048List
+	ret := C.compact_fhe_uint2048_list_try_encrypt_with_compact_public_key_u2048(&inputArray[0], (C.size_t)(len(inputArray)), (*C.CompactPublicKey)(pks), &list)
+	if ret != 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact2048List failed to encrypt with %d", ret)
+	}
+	defer C.compact_fhe_uint2048_list_destroy(list)
+
+	ser := C.DynamicBuffer{}
+	ret = C.compact_fhe_uint2048_list_serialize(list, &ser)
+	if ret != 0 {
+		return nil, fmt.Errorf("EncryptAndSerializeCompact2048List failed to serialize with %d", ret)
+	}
+	defer C.destroy_dynamic_buffer(&ser)
+
+	return C.GoBytes(unsafe.Pointer(ser.pointer), C.int(ser.length)), nil
+}
+
+func DeserializeAndExpandCompact2048List(in []byte) ([]*TfheCiphertext, error) {
+	var list *C.CompactFheUint2048List
+	ret := C.compact_fhe_uint2048_list_deserialize(toDynamicBufferView(in), &list)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact2048List failed to deserialize list with %d", ret)
+	}
+	defer C.compact_fhe_uint2048_list_destroy(list)
+
+	var len C.size_t
+	ret = C.compact_fhe_uint2048_list_len(list, &len)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact2048List failed to get list length with %d", ret)
+	}
+	if len == 0 {
+		return nil, fmt.Errorf("DeserializeCompact2048List length is 0")
+	}
+
+	expanded := make([]*C.FheUint2048, len)
+	ret = C.compact_fhe_uint2048_list_expand(list, &expanded[0], len)
+	if ret != 0 {
+		return nil, fmt.Errorf("DeserializeCompact2048List failed to expand list with %d", ret)
+	}
+	defer func() {
+		for _, c := range expanded {
+			C.destroy_fhe_uint2048(unsafe.Pointer(c))
+		}
+	}()
+
+	cts := make([]*TfheCiphertext, 0, len)
+	for _, c := range expanded {
+		ser, err := serialize(unsafe.Pointer(c), FheUint2048)
+		if err != nil {
+			return nil, err
+		}
+		ct := new(TfheCiphertext)
+		ct.Serialization = ser
+		ct.FheUintType = FheUint2048
+		ct.computeHash()
+		cts = append(cts, ct)
+	}
+	return cts, nil
+}
+
+func castFheUint160To(ct *TfheCiphertext, fheUintType FheUintType) (*TfheCiphertext, error) {
+	ptr160 := C.deserialize_fhe_uint160(toDynamicBufferView(ct.Serialize()))
+	if ptr160 == nil {
+		return nil, errors.New("CastFheUint160To failed to deserialize FheUint160 ciphertext")
+	}
+	defer C.destroy_fhe_uint160(ptr160)
+
+	var err error
+	var resPtr unsafe.Pointer
+	switch fheUintType {
+	case FheBool:
+		var ctNe *TfheCiphertext
+		ctNe, err = ct.ScalarNe(big.NewInt(0))
+		if err != nil {
+			return nil, err
+		}
+		ctNe.computeHash()
+		return ctNe, nil
+	case FheUint4:
+		resPtr = C.cast_160_4(ptr160, sks)
+		defer C.destroy_fhe_uint4(resPtr)
+	case FheUint8:
+		resPtr = C.cast_160_8(ptr160, sks)
+		defer C.destroy_fhe_uint8(resPtr)
+	case FheUint16:
+		resPtr = C.cast_160_16(ptr160, sks)
+		defer C.destroy_fhe_uint16(resPtr)
+	case FheUint32:
+		resPtr = C.cast_160_32(ptr160, sks)
+		defer C.destroy_fhe_uint32(resPtr)
+	case FheUint64:
+		resPtr = C.cast_160_64(ptr160, sks)
+		defer C.destroy_fhe_uint64(resPtr)
+	default:
+		return nil, fmt.Errorf("castFheUint160To invalid type to FheUint160 to: %s", fheUintType.String())
+	}
+
+	res := new(TfheCiphertext)
+	res.Serialization, err = serialize(resPtr, fheUintType)
+	if err != nil {
+		return nil, err
+	}
+	res.FheUintType = fheUintType
+	res.computeHash()
+	return res, nil
 }

--- a/fhevm/tfhe/tfhe_wrappers.h
+++ b/fhevm/tfhe/tfhe_wrappers.h
@@ -57,9 +57,15 @@ void* deserialize_compact_fhe_uint64(DynamicBufferView in);
 
 int serialize_fhe_uint160(void *ct, DynamicBuffer* out);
 
+int serialize_fhe_uint2048(void *ct, DynamicBuffer* out);
+
 void* deserialize_fhe_uint160(DynamicBufferView in);
 
+void* deserialize_fhe_uint2048(DynamicBufferView in);
+
 void* deserialize_compact_fhe_uint160(DynamicBufferView in);
+
+void* deserialize_compact_fhe_uint2048(DynamicBufferView in);
 
 void destroy_fhe_bool(void* ct);
 
@@ -74,6 +80,8 @@ void destroy_fhe_uint32(void* ct);
 void destroy_fhe_uint64(void* ct);
 
 void destroy_fhe_uint160(void* ct);
+
+void destroy_fhe_uint2048(void* ct);
 
 void* add_fhe_uint4(void* ct1, void* ct2, void* sks);
 
@@ -283,6 +291,8 @@ void* eq_fhe_uint64(void* ct1, void* ct2, void* sks);
 
 void* eq_fhe_uint160(void* ct1, void* ct2, void* sks);
 
+void* eq_fhe_uint2048(void* ct1, void* ct2, void* sks);
+
 void* scalar_eq_fhe_uint4(void* ct, uint8_t pt, void* sks);
 
 void* scalar_eq_fhe_uint8(void* ct, uint8_t pt, void* sks);
@@ -294,6 +304,8 @@ void* scalar_eq_fhe_uint32(void* ct, uint32_t pt, void* sks);
 void* scalar_eq_fhe_uint64(void* ct, uint64_t pt, void* sks);
 
 void* scalar_eq_fhe_uint160(void* ct, struct U256 pt, void* sks);
+
+void* scalar_eq_fhe_uint2048(void* ct, struct U2048 pt, void* sks);
 
 void* eq_fhe_array_uint4(void* ct1, size_t ct1_len, void* ct2, size_t ct2_len, void* sks);
 
@@ -317,6 +329,8 @@ void* ne_fhe_uint64(void* ct1, void* ct2, void* sks);
 
 void* ne_fhe_uint160(void* ct1, void* ct2, void* sks);
 
+void* ne_fhe_uint2048(void* ct1, void* ct2, void* sks);
+
 void* scalar_ne_fhe_uint4(void* ct, uint8_t pt, void* sks);
 
 void* scalar_ne_fhe_uint8(void* ct, uint8_t pt, void* sks);
@@ -328,6 +342,8 @@ void* scalar_ne_fhe_uint32(void* ct, uint32_t pt, void* sks);
 void* scalar_ne_fhe_uint64(void* ct, uint64_t pt, void* sks);
 
 void* scalar_ne_fhe_uint160(void* ct, struct U256 pt, void* sks);
+
+void* scalar_ne_fhe_uint2048(void* ct, struct U2048 pt, void* sks);
 
 void* ge_fhe_uint4(void* ct1, void* ct2, void* sks);
 
@@ -495,7 +511,9 @@ int decrypt_fhe_uint32(void* cks, void* ct, uint32_t* res);
 
 int decrypt_fhe_uint64(void* cks, void* ct, uint64_t* res);
 
-int decrypt_fhe_uint160(void* cks, void* ct, struct U256 *res);
+int decrypt_fhe_uint160(void* cks, void* ct, struct U256* res);
+
+int decrypt_fhe_uint2048(void* cks, void* ct, struct U2048* res);
 
 void* public_key_encrypt_fhe_bool(void* pks, bool value);
 
@@ -511,6 +529,8 @@ void* public_key_encrypt_fhe_uint64(void* pks, uint64_t value);
 
 void* public_key_encrypt_fhe_uint160(void* pks, struct U256 *value);
 
+void* public_key_encrypt_fhe_uint2048(void* pks, struct U2048 *value);
+
 void* trivial_encrypt_fhe_bool(void* sks, bool value);
 
 void* trivial_encrypt_fhe_uint4(void* sks, uint8_t value);
@@ -523,7 +543,9 @@ void* trivial_encrypt_fhe_uint32(void* sks, uint32_t value);
 
 void* trivial_encrypt_fhe_uint64(void* sks, uint64_t value);
 
-void* trivial_encrypt_fhe_uint160(void* sks, struct U256 value);
+void* trivial_encrypt_fhe_uint160(void* sks, struct U256* value);
+
+void* trivial_encrypt_fhe_uint2048(void* sks, struct U2048* value);
 
 void public_key_encrypt_and_serialize_fhe_bool_list(void* pks, bool value, DynamicBuffer* out);
 
@@ -538,6 +560,8 @@ void public_key_encrypt_and_serialize_fhe_uint32_list(void* pks, uint32_t value,
 void public_key_encrypt_and_serialize_fhe_uint64_list(void* pks, uint64_t value, DynamicBuffer* out);
 
 void public_key_encrypt_and_serialize_fhe_uint160_list(void* pks, struct U256 *value, DynamicBuffer* out);
+
+void public_key_encrypt_and_serialize_fhe_uint2048_list(void* pks, struct U2048 *value, DynamicBuffer* out);
 
 void* cast_bool_4(void* ct, void* sks);
 
@@ -598,3 +622,13 @@ void* cast_64_8(void* ct, void* sks);
 void* cast_64_16(void* ct, void* sks);
 
 void* cast_64_32(void* ct, void* sks);
+
+void* cast_160_4(void* ct, void* sks);
+
+void* cast_160_8(void* ct, void* sks);
+
+void* cast_160_16(void* ct, void* sks);
+
+void* cast_160_32(void* ct, void* sks);
+
+void* cast_160_64(void* ct, void* sks);


### PR DESCRIPTION
Add support for list-based ciphertext inputs. Two types are supported:
 * CompactFheUint160List
 * CompactFheUint2048List

No other input types are supported. Instead, the `fhevmjs` library encodes any type other than the FheUint2048 type as FheUint160. In fhevm-go during ciphertext verification, we cast it homomorphically to the requested data type. FheUint2048 values are expanded as is, without any casts.

The API of the verifyCiphertext precompile changes such that now it accepts two inputs (through TFHE.asEuintXX() library function in fhevm):
 * bytes32 Handle
 * serialized compact FHE list

Handle format changes and is no longer the hash of the expanded ciphertext. Instead, input handles have the following format:
  * byte 0 to 28: first 29 bytes of keccak256(keccak256(serialized compact FHE list) || index)
 * byte 29: index in the serialized compact FHE list (0-indexed)
 * byte 30: type of the ciphertext
 * byte 31: version

Non-input handles have the following format:
* byte 0 to 29: first 30 bytes of keccak256(serialized compact FHE list)
 * byte 30: type of the ciphertext
 * byte 31: version

Above allows us to pack multiple inputs in one or more CompactFheUint160Lists.

Add support for equality and non-equality of FheUint2048 values.

Cleanup should be done in a future commit in order to remove unused code, duplication and to simplify the implementation and the tests, especially around tfhe-rs handling.