### PR TITLE
feat: add external seed in rand precompile APIs

### DIFF
--- a/fhevm/contracts_test.go
+++ b/fhevm/contracts_test.go
@@ -1687,7 +1687,7 @@ func FheLibBitXor(t *testing.T, fheUintType tfhe.FheUintType, scalar bool) {
 }
 
 func FheLibRand(t *testing.T, fheUintType tfhe.FheUintType) {
-	signature := "fheRand(bytes1)"
+	signature := "fheRand(bytes1,uint256)"
 	depth := 1
 	environment := newTestEVMEnvironment()
 	environment.depth = depth
@@ -1741,7 +1741,7 @@ func FheLibRand(t *testing.T, fheUintType tfhe.FheUintType) {
 }
 
 func FheLibRandBounded(t *testing.T, fheUintType tfhe.FheUintType, upperBound64 uint64) {
-	signature := "fheRandBounded(uint256,bytes1)"
+	signature := "fheRandBounded(uint256,bytes1,uint256)"
 	depth := 1
 	environment := newTestEVMEnvironment()
 	environment.depth = depth

--- a/fhevm/fhelib.go
+++ b/fhevm/fhelib.go
@@ -97,13 +97,13 @@ var fhelibMethods = []*FheLibMethod{
 	},
 	{
 		name:                "fheRand",
-		argTypes:            "(bytes1)",
+		argTypes:            "(bytes1,uint256)",
 		requiredGasFunction: fheRandRequiredGas,
 		runFunction:         fheRandRun,
 	},
 	{
 		name:                "fheRandBounded",
-		argTypes:            "(uint256,bytes1)",
+		argTypes:            "(uint256,bytes1,uint256)",
 		requiredGasFunction: fheRandBoundedRequiredGas,
 		runFunction:         fheRandBoundedRun,
 	},


### PR DESCRIPTION
Needed for the future. Adding it now to stabilize the API of the the rand precompiles. Not used in random computation yet.