### PR TITLE
feat: pass a contract address to verifyCiphertext

### DIFF
--- a/fhevm/contracts_test.go
+++ b/fhevm/contracts_test.go
@@ -237,7 +237,7 @@ func createInputListWithBadIndex(values []big.Int, types []tfhe.FheUintType, lis
 }
 
 func packInputList(handle [32]byte, ciphertext []byte, fheUintType tfhe.FheUintType) []byte {
-	input, err := verifyCipertextMethod.Inputs.Pack(handle, [20]byte{}, ciphertext, [1]byte{byte(fheUintType)})
+	input, err := verifyCipertextMethod.Inputs.Pack(handle, [20]byte{}, [20]byte{}, ciphertext, [1]byte{byte(fheUintType)})
 	if err != nil {
 		panic(err)
 	}

--- a/fhevm/fhelib.go
+++ b/fhevm/fhelib.go
@@ -229,7 +229,7 @@ var fhelibMethods = []*FheLibMethod{
 	},
 	{
 		name:                "verifyCiphertext",
-		argTypes:            "(bytes32,address,bytes,bytes1)",
+		argTypes:            "(bytes32,address,address,bytes,bytes1)",
 		requiredGasFunction: verifyCiphertextRequiredGas,
 		runFunction:         verifyCiphertextRun,
 	},

--- a/fhevm/operators_crypto.go
+++ b/fhevm/operators_crypto.go
@@ -35,6 +35,10 @@ const verifyCipertextAbiJson = `
 					"type": "address"
 				},
 				{
+					"name": "contractAddress",
+					"type": "address"
+				},
+				{
 					"name": "inputProof",
 					"type": "bytes"
 				},
@@ -73,7 +77,7 @@ func parseVerifyCiphertextInput(environment EVMEnvironment, input []byte) ([32]b
 	unpacked, err := verifyCipertextMethod.Inputs.UnpackValues(input)
 	if err != nil {
 		return [32]byte{}, nil, err
-	} else if len(unpacked) != 4 {
+	} else if len(unpacked) != 5 {
 		return [32]byte{}, nil, fmt.Errorf("parseVerifyCiphertextInput unexpected unpacked len: %d", len(unpacked))
 	}
 
@@ -84,13 +88,13 @@ func parseVerifyCiphertextInput(environment EVMEnvironment, input []byte) ([32]b
 	}
 
 	// Get the ciphertext from the input.
-	ciphertextList, ok := unpacked[2].([]byte)
+	ciphertextList, ok := unpacked[3].([]byte)
 	if !ok || len(ciphertextList) == 0 {
 		return [32]byte{}, nil, fmt.Errorf("parseVerifyCiphertextInput failed to parse bytes inputProof")
 	}
 
 	// Get the type from the input.
-	inputTypeByteArray, ok := unpacked[3].([1]byte)
+	inputTypeByteArray, ok := unpacked[4].([1]byte)
 	if !ok {
 		return [32]byte{}, nil, fmt.Errorf("parseVerifyCiphertextInput failed to parse byte inputType")
 	}


### PR DESCRIPTION
Will be needed in the future to verify the input ZKPoK.