### PR TITLE
fix: do not persist FHE public key hash in state

### DIFF
--- a/fhevm/evm.go
+++ b/fhevm/evm.go
@@ -66,17 +66,7 @@ func insertRandomCiphertext(environment EVMEnvironment, t tfhe.FheUintType) []by
 	return ct.GetHash().Bytes()
 }
 
-func InitFhevm(accessibleState EVMEnvironment) {
-	persistFhePubKeyHash(accessibleState)
-}
-
-func persistFhePubKeyHash(accessibleState EVMEnvironment) {
-	existing := accessibleState.GetState(fhePubKeyHashPrecompile, fhePubKeyHashSlot)
-	if newInt(existing[:]).IsZero() {
-		var pksHash = tfhe.GetPksHash()
-		accessibleState.SetState(fhePubKeyHashPrecompile, fhePubKeyHashSlot, pksHash)
-	}
-}
+func InitFhevm(accessibleState EVMEnvironment) {}
 
 func Create(evm EVMEnvironment, caller common.Address, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	contractAddr = crypto.CreateAddress(caller, evm.GetNonce(caller))

--- a/fhevm/operators_crypto.go
+++ b/fhevm/operators_crypto.go
@@ -319,18 +319,9 @@ func castRun(environment EVMEnvironment, caller common.Address, addr common.Addr
 	return resHash.Bytes(), nil
 }
 
-var fhePubKeyHashPrecompile = common.BytesToAddress([]byte{93})
-var fhePubKeyHashSlot = common.Hash{}
-
 func fhePubKeyRun(environment EVMEnvironment, caller common.Address, addr common.Address, input []byte, readOnly bool, runSpan trace.Span) ([]byte, error) {
 	input = input[:minInt(1, len(input))]
 
-	existing := environment.GetState(fhePubKeyHashPrecompile, fhePubKeyHashSlot)
-	if existing != tfhe.GetPksHash() {
-		msg := "fhePubKey FHE public key hash doesn't match one stored in state"
-		environment.GetLogger().Error(msg, "existing", existing.Hex(), "pksHash", tfhe.GetPksHash().Hex())
-		return nil, errors.New(msg)
-	}
 	// serialize public key
 	pksBytes, err := tfhe.SerializePublicKey()
 	if err != nil {


### PR DESCRIPTION
Persisting the FHE public key hash in state brings more issues (i.e. during deployment) than benefits. Furthermore, we will be changing the FHE keys in the future and that will require a redesign anyway.