### PR TITLE
fix: call otel describe functions after err checks

### DIFF
--- a/fhevm/operators_arithmetic.go
+++ b/fhevm/operators_arithmetic.go
@@ -21,11 +21,11 @@ func fheAddRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheAdd failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheAdd operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -50,11 +50,11 @@ func fheAddRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheAdd scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -87,11 +87,11 @@ func fheSubRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheSub failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheSub operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -116,11 +116,11 @@ func fheSubRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheSub scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -153,11 +153,11 @@ func fheMulRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMul failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheMul operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -182,11 +182,11 @@ func fheMulRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMul scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -223,11 +223,11 @@ func fheDivRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 		return nil, err
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheDiv scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -264,11 +264,11 @@ func fheRemRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 		return nil, err
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheRem scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {

--- a/fhevm/operators_bit.go
+++ b/fhevm/operators_bit.go
@@ -21,11 +21,11 @@ func fheShlRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheShl failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheShl operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -50,11 +50,11 @@ func fheShlRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheShl scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -87,11 +87,11 @@ func fheShrRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheShr failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheShr operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -116,11 +116,11 @@ func fheShrRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheShr scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -153,11 +153,11 @@ func fheRotlRun(environment EVMEnvironment, caller common.Address, addr common.A
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheShl failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheShl operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -182,11 +182,11 @@ func fheRotlRun(environment EVMEnvironment, caller common.Address, addr common.A
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheRotl scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -219,11 +219,11 @@ func fheRotrRun(environment EVMEnvironment, caller common.Address, addr common.A
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheRotr failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheRotr operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -248,11 +248,11 @@ func fheRotrRun(environment EVMEnvironment, caller common.Address, addr common.A
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheRotr scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -364,11 +364,11 @@ func fheBitAndRun(environment EVMEnvironment, caller common.Address, addr common
 	}
 
 	lhs, rhs, _, err := load2Ciphertexts(environment, input)
-	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 	if err != nil {
 		logger.Error("fheBitAnd failed to load inputs", "err", err)
 		return nil, err
 	}
+	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 
 	if lhs.Type() != rhs.Type() {
 		msg := "fheBitAnd operand type mismatch"
@@ -411,11 +411,11 @@ func fheBitOrRun(environment EVMEnvironment, caller common.Address, addr common.
 	}
 
 	lhs, rhs, _, err := load2Ciphertexts(environment, input)
-	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 	if err != nil {
 		logger.Error("fheBitOr failed to load inputs", "err", err)
 		return nil, err
 	}
+	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 
 	if lhs.Type() != rhs.Type() {
 		msg := "fheBitOr operand type mismatch"
@@ -458,11 +458,11 @@ func fheBitXorRun(environment EVMEnvironment, caller common.Address, addr common
 	}
 
 	lhs, rhs, _, err := load2Ciphertexts(environment, input)
-	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 	if err != nil {
 		logger.Error("fheBitXor failed to load inputs", "err", err)
 		return nil, err
 	}
+	otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 
 	if lhs.Type() != rhs.Type() {
 		msg := "fheBitXor operand type mismatch"

--- a/fhevm/operators_comparison.go
+++ b/fhevm/operators_comparison.go
@@ -26,11 +26,11 @@ func fheLeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheLe failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheLe operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -55,11 +55,11 @@ func fheLeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheLe scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -92,11 +92,11 @@ func fheLtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheLt failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheLt operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -121,11 +121,11 @@ func fheLtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheLt scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -158,11 +158,11 @@ func fheEqRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheEq dailed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheEq operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -187,11 +187,11 @@ func fheEqRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheEq scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -224,11 +224,11 @@ func fheGeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheGe failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheGe operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -253,11 +253,11 @@ func fheGeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheGe scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -290,11 +290,11 @@ func fheGtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheGt failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheGt operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -319,11 +319,11 @@ func fheGtRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheGt scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -356,11 +356,11 @@ func fheNeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheNe failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheNe operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -385,11 +385,11 @@ func fheNeRun(environment EVMEnvironment, caller common.Address, addr common.Add
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheNe scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -422,11 +422,11 @@ func fheMinRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMin failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheMin operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -451,11 +451,11 @@ func fheMinRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMin scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -488,11 +488,11 @@ func fheMaxRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	if !isScalar {
 		lhs, rhs, _, err := load2Ciphertexts(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMax failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), encryptedOperand(*rhs))
 		if lhs.Type() != rhs.Type() {
 			msg := "fheMax operand type mismatch"
 			logger.Error(msg, "lhs", lhs.Type(), "rhs", rhs.Type())
@@ -517,11 +517,11 @@ func fheMaxRun(environment EVMEnvironment, caller common.Address, addr common.Ad
 
 	} else {
 		lhs, rhs, _, err := getScalarOperands(environment, input)
-		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 		if err != nil {
 			logger.Error("fheMax scalar failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 			return nil, err
 		}
+		otelDescribeOperands(runSpan, encryptedOperand(*lhs), plainOperand(*rhs))
 
 		// If we are doing gas estimation, skip execution and insert a random ciphertext as a result.
 		if !environment.IsCommitting() && !environment.IsEthCall() {
@@ -546,11 +546,11 @@ func fheIfThenElseRun(environment EVMEnvironment, caller common.Address, addr co
 
 	logger := environment.GetLogger()
 	first, second, third, _, err := load3Ciphertexts(environment, input)
-	otelDescribeOperands(runSpan, encryptedOperand(*first), encryptedOperand(*second), encryptedOperand(*third))
 	if err != nil {
 		logger.Error("fheIfThenElse failed to load inputs", "err", err, "input", hex.EncodeToString(input))
 		return nil, err
 	}
+	otelDescribeOperands(runSpan, encryptedOperand(*first), encryptedOperand(*second), encryptedOperand(*third))
 
 	if second.Type() != third.Type() {
 		msg := "fheIfThenElse operand type mismatch"

--- a/fhevm/operators_rand.go
+++ b/fhevm/operators_rand.go
@@ -166,12 +166,12 @@ func fheRandBoundedRun(environment EVMEnvironment, caller common.Address, addr c
 		return nil, errors.New(msg)
 	}
 	randType, bound, err := parseRandUpperBoundInput(input)
-	otelDescribeOperandsFheTypes(runSpan, randType)
 	if err != nil {
 		msg := "fheRandBounded bound error"
 		logger.Error(msg, "input", hex.EncodeToString(input), "err", err)
 		return nil, errors.New(msg)
 	}
+	otelDescribeOperandsFheTypes(runSpan, randType)
 	bound64 := bound.Uint64()
 	return generateRandom(environment, caller, randType, &bound64)
 }


### PR DESCRIPTION
Make sure we call otel functions that describe operand types after doing a check for an error. That avoids a possible nil pointer dereference.

Rename `ciphertextStorage` to `CiphertextStorageAddress` such that it is public and can be used by clients.